### PR TITLE
Move from failure (deprecated) to thiserror.

### DIFF
--- a/lifx-core/Cargo.toml
+++ b/lifx-core/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.2.4"
-failure = "0.1.2"
-failure_derive = "0.1.2"
+thiserror = "1.0"
+

--- a/lifx-core/Cargo.toml
+++ b/lifx-core/Cargo.toml
@@ -11,4 +11,3 @@ edition = "2018"
 [dependencies]
 byteorder = "1.2.4"
 thiserror = "1.0"
-

--- a/lifx-core/src/lib.rs
+++ b/lifx-core/src/lib.rs
@@ -24,42 +24,31 @@
 //! suspected to be internal messages that are used by offical LIFX apps, but that aren't documented.
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use failure_derive::Fail;
+use thiserror::Error;
 use std::convert::{TryFrom, TryInto};
 use std::io::Cursor;
 use std::{fmt, io};
 
 /// Various message encoding/decoding errors
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// This error means we were unable to parse a raw message because its type is unknown.
     ///
     /// LIFX devices are known to send messages that are not officially documented, so this error
     /// type does not necessarily represent a bug.
+    #[error("unknown message type: `{0}`")]
     UnknownMessageType(u16),
-
     /// This error means one of the message fields contains an invalid or unsupported value.
-    ///
-    /// The inner string is a description of the error.
+    #[error("protocol error: `{0}`")]
     ProtocolError(String),
-    Io(#[cause] io::Error),
-}
 
-impl std::convert::From<io::Error> for Error {
-    fn from(io: io::Error) -> Self {
-        Error::Io(io)
-    }
+    #[error("i/o error")]
+    Io(#[from] io::Error),
 }
 
 impl From<std::convert::Infallible> for Error {
     fn from(_: std::convert::Infallible) -> Self {
         unreachable!()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "An error occurred.")
     }
 }
 

--- a/lifx-core/src/lib.rs
+++ b/lifx-core/src/lib.rs
@@ -27,7 +27,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use thiserror::Error;
 use std::convert::{TryFrom, TryInto};
 use std::io::Cursor;
-use std::{fmt, io};
+use std::io;
 
 /// Various message encoding/decoding errors
 #[derive(Error, Debug)]


### PR DESCRIPTION
failure was deprecated in https://github.com/rust-lang-nursery/failure/pull/347, in that commit thiserror was recommended as a drop-in replacement.

This change allows improved handling of lifx_core::Error.